### PR TITLE
Add prefix option to config

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ Example add-on configuration:
     "username": "glances",
     "password": "!secret glances_influxdb_password",
     "database": "glances",
-    "prefix": "`hostname`",
+    "prefix": "localhost",
     "interval": 60
   }
 }

--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ Example add-on configuration:
     "username": "glances",
     "password": "!secret glances_influxdb_password",
     "database": "glances",
+    "prefix": "`hostname`",
     "interval": 60
   }
 }
@@ -147,6 +148,10 @@ The password for the above username option.
 #### Option `influxdb`: `database`
 
 The name of the database to store all Glances information into.
+
+#### Option `prefix`: `\`hostname\``
+
+This add's the hostname dynamically using the system command for exported data.
 
 **Note**: _It is strongly recommended to create a separate database for glances
 and not store this in the same database name as Home Assistant._

--- a/README.md
+++ b/README.md
@@ -149,9 +149,9 @@ The password for the above username option.
 
 The name of the database to store all Glances information into.
 
-#### Option `prefix`: `\`hostname\``
+#### Option `prefix`: `localhost`
 
-This add's the hostname dynamically using the system command for exported data.
+The hostname to append for exported data **Note for the Grafana Glances dashboard set this to localhost.
 
 **Note**: _It is strongly recommended to create a separate database for glances
 and not store this in the same database name as Home Assistant._

--- a/glances/config.json
+++ b/glances/config.json
@@ -39,6 +39,7 @@
       "username": "glances",
       "password": "",
       "database": "glances",
+      "prefix": "`hostname`",
       "interval": 60
     }
   },
@@ -54,6 +55,7 @@
       "username": "str",
       "password": "str",
       "database": "str",
+      "prefix": "str",
       "interval": "int"
     },
     "leave_front_door_open": "bool?"

--- a/glances/config.json
+++ b/glances/config.json
@@ -39,7 +39,7 @@
       "username": "glances",
       "password": "",
       "database": "glances",
-      "prefix": "`hostname`",
+      "prefix": "localhost",
       "interval": 60
     }
   },

--- a/glances/rootfs/etc/cont-init.d/30-influxdb.sh
+++ b/glances/rootfs/etc/cont-init.d/30-influxdb.sh
@@ -17,5 +17,6 @@ fi
     echo "port=$(hass.config.get 'influxdb.port')"
     echo "user=$(hass.config.get 'influxdb.username')"
     echo "password=$(hass.config.get 'influxdb.password')"
+    echo "prefix=$(hass.config.get 'influxdb.prefix')"
     echo "db=$(hass.config.get 'influxdb.database')"
 } >> /etc/glances.conf

--- a/glances/rootfs/etc/cont-init.d/30-influxdb.sh
+++ b/glances/rootfs/etc/cont-init.d/30-influxdb.sh
@@ -17,6 +17,6 @@ fi
     echo "port=$(hass.config.get 'influxdb.port')"
     echo "user=$(hass.config.get 'influxdb.username')"
     echo "password=$(hass.config.get 'influxdb.password')"
-    echo "prefix=$(hass.config.get 'influxdb.prefix')"
     echo "db=$(hass.config.get 'influxdb.database')"
+    echo "prefix=$(hass.config.get 'influxdb.prefix')"
 } >> /etc/glances.conf


### PR DESCRIPTION
# Proposed Changes
Changed config files and documentation to include prefix option. This adds a user definable prefix of localhost. This was necessary to support the Grafana Glances dashboard out of the box.

## Related Issues
https://grafana.com/dashboards/2387/revisions
![2019-02-03 2](https://user-images.githubusercontent.com/46015702/52184027-b339c080-27d3-11e9-8912-ee4684b9a6d3.png)



<blockquote><img src="https://grafana.com/api/dashboards/2387/logos/large" width="48" align="right"><div>Grafana Labs</div><div><strong><a href="https://grafana.com/dashboards/2387/revisions">Glances dashboard for Grafana</a></strong></div><div>Data visualization & monitoring with support for Graphite, InfluxDB, Prometheus, Elasticsearch and many more databases</div></blockquote>