### PR TITLE
🔨Add optional configuration for history_size

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,11 @@ The private key file to use for SSL.
 
 **Note**: _The file MUST be stored in `/ssl/`, which is the default_
 
+### Option: `history_size`
+
+If specified changes the time Glances will retain data.  Default if not set is
+28800: 1 day with 1 point every 3 seconds.
+
 ### Option group `influxdb`
 
 ---

--- a/glances/config.json
+++ b/glances/config.json
@@ -51,6 +51,7 @@
     "ssl": "bool",
     "certfile": "str",
     "keyfile": "str",
+    "history_size": "int?",
     "influxdb": {
       "enabled": "bool",
       "host": "str",

--- a/glances/rootfs/etc/cont-init.d/glances.sh
+++ b/glances/rootfs/etc/cont-init.d/glances.sh
@@ -17,6 +17,13 @@ else
     cp /etc/glances.conf /config/glances/
 fi
 
+# Set History Size
+history_size=28800
+  if bashio::config.exists 'history_size'; then
+    history_size=$(bashio::config 'history_size')
+  fi
+sed -i "s#history_size=28800#history_size=${history_size}#g" /etc/glances.conf
+
 # Export Glances data to InfluxDB
 if bashio::config.true 'influxdb.enabled'; then
     protocol='http'


### PR DESCRIPTION
# Proposed Changes

Add history_size to configuration as optional.

As a side note I think we need to look at how the glances.conf is copied in, as I believe it will always use the one from /config/glances/glances.conf

## Related Issues

#61 
