### PR TITLE
Remove obsolete webui from configuration

### DIFF
--- a/glances/config.json
+++ b/glances/config.json
@@ -4,7 +4,6 @@
   "slug": "glances",
   "description": "A cross-platform system monitoring tool",
   "url": "https://github.com/hassio-addons/addon-glances",
-  "webui": "[PROTO:ssl]://[HOST]:[PORT:80]",
   "ingress": true,
   "ingress_port": 0,
   "panel_icon": "mdi:speedometer",


### PR DESCRIPTION
# Proposed Changes

Removes the webui configuration option, it doesn't do anything, since this add-on uses Ingress.