### PR TITLE
🔥 Less logging by removing access log from log ouput

### DIFF
--- a/glances/rootfs/etc/nginx/nginx.conf
+++ b/glances/rootfs/etc/nginx/nginx.conf
@@ -27,11 +27,7 @@ events {
 http {
     include /etc/nginx/includes/mime.types;
 
-    log_format homeassistant '[$time_local] $status '
-                             '$http_x_forwarded_for($remote_addr) '
-                             '$request ($http_user_agent)';
-
-    access_log              /dev/stdout homeassistant;
+    access_log              off;
     client_max_body_size    4G;
     default_type            application/octet-stream;
     gzip                    on;


### PR DESCRIPTION
# Proposed Changes

Remove NGINX access logs from the add-on log output, making it less chatty