### PR TITLE
Add support for exporting to influxdb v2.

### DIFF
--- a/glances/DOCS.md
+++ b/glances/DOCS.md
@@ -41,6 +41,15 @@ influxdb:
   prefix: localhost
   interval: 60
   ssl: false
+influxdb2:
+  enabled: false
+  host: my.influxdb.host
+  port: 8086
+  token: "!secret glances_influxdbv2_token"
+  bucket: glances
+  org: myorg
+  interval: 60
+  ssl: false
 ```
 
 **Note**: _This is just an example, don't copy and paste it! Create your own!_
@@ -142,6 +151,57 @@ The hostname to append for exported data.
 Defines the interval (in seconds) on how often Glances exports data to InfluxDB.
 
 #### Option `influxdb`: `ssl`
+
+Adding this option will allow SSL to be used on the InfluxDB connection. If not
+set will default to `false` which is the required setting for the Community
+InfluxDB add-on.
+
+### Option group `influxdb2`
+
+These options apply to data export to an InfluxDB v2.x database.
+
+---
+
+The following options are for the option group: `influxdb2`. These settings
+only apply to the Glances InfluxDB v2.x data export.
+
+#### Option `influxdb2`: `enabled`
+
+Enables/Disables the Glances data export to InfluxDB.
+
+#### Option `influxdb2`: `host`
+
+The hostname where InfluxDB is running.
+
+#### Option `influxdb2`: `port`
+
+The port on which InfluxDB is listening.
+
+#### Option `influxdb2`: `token`
+
+An InfluxDB token with permissions to write to the given bucket. This should
+look like `t9iHPiGQyg0ds4K1IlBrCyBsNGh71dkdR6u8Y9eeR37UzfGuFukFCdbMI4YA9EtKb4zr5coFXKw67tbBEP7CPw==`
+
+#### Option `influxdb2`: `bucket`
+
+The name of the bucket to store all Glances information into.
+
+**Note**: _It is strongly recommended to create a separate bucket for glances
+and not store this in the same bucket as Home Assistant._
+
+#### Option `influxdb2`: `organization`
+
+The InfluxDB organization that owns the given bucket.
+
+#### Option `prefix`: `localhost`
+
+The hostname to append for exported data.
+
+#### Option `influxdb2`: `interval`
+
+Defines the interval (in seconds) on how often Glances exports data to InfluxDB.
+
+#### Option `influxdb2`: `ssl`
 
 Adding this option will allow SSL to be used on the InfluxDB connection. If not
 set will default to `false` which is the required setting for the Community

--- a/glances/config.json
+++ b/glances/config.json
@@ -40,6 +40,16 @@
       "database": "glances",
       "prefix": "localhost",
       "interval": 60
+    },
+    "influxdb2": {
+      "enabled": false,
+      "host": "",
+      "port": 8086,
+      "token": "",
+      "bucket": "glances",
+      "organization": "",
+      "prefix": "localhost",
+      "interval": 60
     }
   },
   "schema": {
@@ -56,6 +66,17 @@
       "username": "str",
       "password": "password",
       "database": "str",
+      "prefix": "str",
+      "interval": "int",
+      "ssl": "bool?"
+    },
+    "influxdb2": {
+      "enabled": "bool",
+      "host": "str",
+      "port": "port",
+      "token": "str",
+      "bucket": "str",
+      "organization": "str",
       "prefix": "str",
       "interval": "int",
       "ssl": "bool?"

--- a/glances/requirements.txt
+++ b/glances/requirements.txt
@@ -2,6 +2,7 @@ bottle==0.12.19
 docker==5.0.3
 glances==3.2.3.1
 influxdb==5.3.1
+influxdb-client==1.21.0
 netifaces==0.11.0
 paho-mqtt==1.5.1
 psutil==5.8.0

--- a/glances/rootfs/etc/cont-init.d/glances.sh
+++ b/glances/rootfs/etc/cont-init.d/glances.sh
@@ -18,12 +18,13 @@ else
 fi
 
 # Export Glances data to InfluxDB
+# See https://glances.readthedocs.io/en/latest/gw/influxdb.html for
+# configuration docs
 if bashio::config.true 'influxdb.enabled'; then
     protocol='http'
     if bashio::config.true 'influxdb.ssl'; then
     protocol='https'
     fi
-    # Modify the configuration
     {
         echo "[influxdb]"
         echo "host=$(bashio::config 'influxdb.host')"
@@ -31,6 +32,22 @@ if bashio::config.true 'influxdb.enabled'; then
         echo "user=$(bashio::config 'influxdb.username')"
         echo "password=$(bashio::config 'influxdb.password')"
         echo "db=$(bashio::config 'influxdb.database')"
+        echo "prefix=$(bashio::config 'influxdb.prefix')"
+        echo "protocol=${protocol}"
+    } >> /etc/glances.conf
+fi
+if bashio::config.true 'influxdb2.enabled'; then
+    protocol='http'
+    if bashio::config.true 'influxdb2.ssl'; then
+    protocol='https'
+    fi
+    {
+        echo "[influxdb2]"
+        echo "host=$(bashio::config 'influxdb2.host')"
+        echo "port=$(bashio::config 'influxdb2.port')"
+        echo "token=$(bashio::config 'influxdb2.token')"
+        echo "bucket=$(bashio::config 'influxdb2.bucket')"
+        echo "org=$(bashio::config 'influxdb2.organization')"
         echo "prefix=$(bashio::config 'influxdb.prefix')"
         echo "protocol=${protocol}"
     } >> /etc/glances.conf

--- a/glances/rootfs/etc/services.d/influxdb/run
+++ b/glances/rootfs/etc/services.d/influxdb/run
@@ -5,27 +5,40 @@
 # ==============================================================================
 declare -a options
 
-if bashio::config.false 'influxdb.enabled'; then
+if bashio::config.false 'influxdb.enabled' && bashio::config.false 'influxdb2.enabled'; then
+    # This script is re-run by systemd whenever it terminates, so sleep for a
+    # while to avoid a continual loop.
     exec sleep 86400
 fi
 
-options+=(-C /etc/glances.conf)
-options+=(--export influxdb)
-options+=(--quiet)
+function glances_export() {
+    influxdb_version="$1"
+    sleep_interval="$2"
 
-options+=(--time "$(bashio::config 'refresh_time')")
+    options+=(-C /etc/glances.conf)
+    options+=(--export "$influxdb_version")
+    options+=(--quiet)
 
-if bashio::config.false 'process_info'; then
-    options+=(--disable-process)
+    options+=(--time "$(bashio::config 'refresh_time')")
+
+    if bashio::config.false 'process_info'; then
+        options+=(--disable-process)
+    fi
+
+    if bashio::debug; then
+        options+=(--debug)
+    fi
+
+    sleep "$sleep_interval"
+    glances "${options[@]}"
+}
+
+# Run the export processes in the background, then wait for both to complete
+# (otherwise we delay one export by the other's interval).
+if bashio::config.true 'influxdb.enabled'; then
+    glances_export "influxdb" "$(bashio::config 'influxdb.interval')" &
 fi
-
-if bashio::debug; then
-    options+=(--debug)
+if bashio::config.true 'influxdb2.enabled'; then
+    glances_export "influxdb2" "$(bashio::config 'influxdb2.interval')" &
 fi
-
-# Interval
-sleep "$(bashio::config 'influxdb.interval')"
-
-# Run Glances
-exec glances "${options[@]}"
-
+wait


### PR DESCRIPTION
# Proposed Changes

Add configuration options+change influxdb service script to support Glances writing to an InfluxDB 2.x database.

I've tested this using a local addon, and was able to write to both a v1 database (the influxdb HA addon) and a v2 database (an external database running on a different host) at the same time, as well as just writing to one with the other disabled.

Question: I'm not familiar with how existing configurations are handled with addon upgrades: I've added some _required_ fields in this commit, does that mean everyone who upgrades to a version including this commit will need to update their configs to set the required fields to something? Or will HA somehow merge the configs when updating so people won't notice the change? This option set felt best as a separate dictionary, but that means the change isn't really backwards- or forwards- compatible.

## Related Issues

- https://github.com/hassio-addons/addon-glances/issues/205