### PR TITLE
:arrow_down: Downgrade psutil to 5.7.3

### DIFF
--- a/glances/requirements.txt
+++ b/glances/requirements.txt
@@ -4,7 +4,7 @@ glances==3.2.3.1
 influxdb==5.3.1
 netifaces==0.11.0
 paho-mqtt==1.6.1
-psutil==5.8.0
+psutil==5.7.3
 py-cpuinfo==8.0.0
 requests==2.26.0
 scandir==1.10.0


### PR DESCRIPTION
# Proposed Changes

Downgrades psutil to 5.7.3. 
Glances is unable to locate psutil 5.8.0 for some reason 🤷‍♂️ 
