### PR TITLE
Fix incorrect documentation block in nginx service script

### DIFF
--- a/glances/rootfs/etc/cont-init.d/nginx.sh
+++ b/glances/rootfs/etc/cont-init.d/nginx.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bashio
 # ==============================================================================
-# Home Assistant Community Add-on: SSH & Web Terminal
-# Configures NGINX for use with ttyd
+# Home Assistant Community Add-on: Glances
+# Configures NGINX for use with Glances
 # ==============================================================================
 
 # Generate Ingress configuration


### PR DESCRIPTION
# Proposed Changes

just fix a typo ^^. for the name of the addon

## Related Issues

> ([Github link][autolink-references] to related issues or pull requests)

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/
