### PR TITLE
Add python3-dev to build dependencies

### DIFF
--- a/glances/Dockerfile
+++ b/glances/Dockerfile
@@ -14,6 +14,7 @@ RUN \
     apk add --no-cache --virtual .build-dependencies \
         build-base=0.5-r3 \
         py3-pip=22.1.1-r0 \
+        python3-dev=3.10.5-r0 \
     \
     && apk add --no-cache \
         nginx=1.22.0-r1 \


### PR DESCRIPTION
# Proposed Changes

Should not be needed at the moment as HA wheels include psutil 5.9.2 now, but good to have for future build IMO.

## Related Issues

N/A