### PR TITLE
Fix influxdb start by adding six as dependency

### DIFF
--- a/glances/requirements.txt
+++ b/glances/requirements.txt
@@ -10,3 +10,4 @@ requests==2.28.1
 scandir==1.10.0
 wifi==0.3.8
 zeroconf==0.39.4
+six==1.16.0


### PR DESCRIPTION
# Proposed Changes

InfluxDB integration is not starting because the dependency to `six` is missing. This adds it as a requirement.

## Related Issues

#296
