### PR TITLE
Remove obsolete requirements

### DIFF
--- a/glances/requirements.txt
+++ b/glances/requirements.txt
@@ -8,6 +8,5 @@ psutil==5.9.4
 py-cpuinfo==9.0.0
 requests==2.28.1
 scandir==1.10.0
-wifi==0.3.8
-zeroconf==0.39.4
 six==1.16.0
+zeroconf==0.39.4

--- a/glances/requirements.txt
+++ b/glances/requirements.txt
@@ -8,5 +8,4 @@ psutil==5.9.4
 py-cpuinfo==9.0.0
 requests==2.28.1
 scandir==1.10.0
-six==1.16.0
 zeroconf==0.39.4


### PR DESCRIPTION
# Proposed Changes

Remove obsolete wifi package, not compatible with python3 and glances disables the plugin.
Also removed six again because that seemed fixed by #303 as well.