### PR TITLE
add support influxdb2 (#311)Co-authored-by: Franck Nijhof <git@frenck.dev>

### DIFF
--- a/glances/DOCS.md
+++ b/glances/DOCS.md
@@ -39,12 +39,20 @@ influxdb:
   enabled: false
   host: a0d7b954-influxdb
   port: 8086
+  interval: 60
+  ssl: false
+  prefix: localhost
+  version: 1 # Either 1 or 2
+
+  # Version 1
   username: glances
   password: "!secret glances_influxdb_password"
   database: glances
-  prefix: localhost
-  interval: 60
-  ssl: false
+
+  # Version 2
+  token: "!secret glances_influxdb2_token"
+  bucket: glances
+  org: myorg
 ```
 
 **Note**: _This is just an example, don't copy and paste it! Create your own!_
@@ -119,28 +127,6 @@ use `a0d7b954-influxdb` as the hostname._
 
 The port on which InfluxDB is listening.
 
-#### Option `influxdb`: `username`
-
-The username that you have created for Glances to authenticate against
-InfluxDB.
-
-#### Option `influxdb`: `password`
-
-The password for the above username option.
-
-#### Option `influxdb`: `database`
-
-The name of the database to store all Glances information into.
-
-**Note**: _It is strongly recommended to create a separate database for glances
-and not store this in the same database name as Home Assistant._
-
-#### Option `prefix`: `localhost`
-
-The hostname to append for exported data.
-
-**Note**: _For the Grafana Glances dashboard set this to `localhost`._
-
 #### Option `influxdb`: `interval`
 
 Defines the interval (in seconds) on how often Glances exports data to InfluxDB.
@@ -150,6 +136,60 @@ Defines the interval (in seconds) on how often Glances exports data to InfluxDB.
 Adding this option will allow SSL to be used on the InfluxDB connection. If not
 set will default to `false` which is the required setting for the Community
 InfluxDB add-on.
+
+#### Option `influxdb`: `prefix`
+
+The hostname to append for exported data.
+
+**Note**: _For the Grafana Glances dashboard set this to `localhost`._
+
+#### Option `influxdb`: `version`
+
+The influxdb version to connecting. Either **1** or **2**.
+
+#### Option `influxdb`: `username`
+
+> Applied to version 1 only
+
+The username that you have created for Glances to authenticate against
+InfluxDB.
+
+#### Option `influxdb`: `password`
+
+> Applied to version 1 only
+
+The password for the above username option.
+
+#### Option `influxdb`: `database`
+
+> Applied to version 1 only
+
+The name of the database to store all Glances information into.
+
+**Note**: _It is strongly recommended to create a separate database for glances
+and not store this in the same database name as Home Assistant._
+
+#### Option `influxdb`: `token`
+
+> Applied to version 2 only
+
+An InfluxDB token with permissions to write to the given bucket. This should
+look like `t9iHPiGQyg0ds4K1IlBrCyBsNGh71dkdR6u8Y9eeR37UzfGuFukFCdbMI4YA9EtKb4zr5coFXKw67tbBEP7CPw==`
+
+#### Option `influxdb`: `bucket`
+
+> Applied to version 1 only
+
+The name of the bucket to store all Glances information into.
+
+**Note**: _It is strongly recommended to create a separate bucket for glances
+and not store this in the same bucket as Home Assistant._
+
+#### Option `influxdb`: `organization`
+
+> Applied to version 1 only
+
+The InfluxDB organization that owns the given bucket.
 
 ## Adding Glances as a sensor into Home Assistant
 

--- a/glances/config.yaml
+++ b/glances/config.yaml
@@ -45,11 +45,16 @@ options:
     enabled: false
     host: a0d7b954-influxdb
     port: 8086
+    interval: 60
+    ssl: false
+    version: 1
     username: glances
     password: ""
     database: glances
     prefix: localhost
-    interval: 60
+    token: ""
+    bucket: glances
+    org: myorg
 schema:
   log_level: list(trace|debug|info|notice|warning|error|fatal)
   process_info: bool

--- a/glances/requirements.txt
+++ b/glances/requirements.txt
@@ -2,6 +2,7 @@ bottle==0.12.25
 docker==6.0.1
 glances==3.3.1.1
 influxdb==5.3.1
+influxdb-client==1.21.0
 netifaces==0.11.0
 paho-mqtt==1.6.1
 psutil==5.9.4

--- a/glances/rootfs/etc/cont-init.d/glances.sh
+++ b/glances/rootfs/etc/cont-init.d/glances.sh
@@ -3,7 +3,7 @@
 # Home Assistant Community Add-on: Glances
 # Configures Glances
 # ==============================================================================
-declare protocol
+declare header protocol
 bashio::require.unprotected
 
 # Ensure the configuration exists
@@ -23,15 +23,32 @@ if bashio::config.true 'influxdb.enabled'; then
     if bashio::config.true 'influxdb.ssl'; then
     protocol='https'
     fi
+
+    header='influxdb'
+    if bashio::config.equals 'influxdb.version' '2'; then
+    header='influxdb2'
+    fi
+
     # Modify the configuration
     {
-        echo "[influxdb]"
+        echo "[${header}]"
+        echo "protocol=${protocol}"
         echo "host=$(bashio::config 'influxdb.host')"
         echo "port=$(bashio::config 'influxdb.port')"
-        echo "user=$(bashio::config 'influxdb.username')"
-        echo "password=$(bashio::config 'influxdb.password')"
-        echo "db=$(bashio::config 'influxdb.database')"
         echo "prefix=$(bashio::config 'influxdb.prefix')"
-        echo "protocol=${protocol}"
     } >> /etc/glances.conf
+
+    if bashio::config.equals 'influxdb.version' '1'; then
+        {
+            echo "user=$(bashio::config 'influxdb.username')"
+            echo "password=$(bashio::config 'influxdb.password')"
+            echo "db=$(bashio::config 'influxdb.database')"
+        } >> /etc/glances.conf
+    elif bashio::config.equals 'influxdb.version' '2'; then
+        {
+            echo "org=$(bashio::config 'influxdb.organization')"
+            echo "bucket=$(bashio::config 'influxdb.bucket')"
+            echo "token=$(bashio::config 'influxdb.token')"
+        } >> /etc/glances.conf
+    fi
 fi

--- a/glances/rootfs/etc/cont-init.d/glances.sh
+++ b/glances/rootfs/etc/cont-init.d/glances.sh
@@ -3,7 +3,7 @@
 # Home Assistant Community Add-on: Glances
 # Configures Glances
 # ==============================================================================
-declare header protocol
+declare protocol
 bashio::require.unprotected
 
 # Ensure the configuration exists
@@ -21,34 +21,30 @@ fi
 if bashio::config.true 'influxdb.enabled'; then
     protocol='http'
     if bashio::config.true 'influxdb.ssl'; then
-    protocol='https'
-    fi
-
-    header='influxdb'
-    if bashio::config.equals 'influxdb.version' '2'; then
-    header='influxdb2'
+        protocol='https'
     fi
 
     # Modify the configuration
-    {
-        echo "[${header}]"
-        echo "protocol=${protocol}"
-        echo "host=$(bashio::config 'influxdb.host')"
-        echo "port=$(bashio::config 'influxdb.port')"
-        echo "prefix=$(bashio::config 'influxdb.prefix')"
-    } >> /etc/glances.conf
-
     if bashio::config.equals 'influxdb.version' '1'; then
         {
+            echo "[influxb]"
             echo "user=$(bashio::config 'influxdb.username')"
             echo "password=$(bashio::config 'influxdb.password')"
             echo "db=$(bashio::config 'influxdb.database')"
         } >> /etc/glances.conf
     elif bashio::config.equals 'influxdb.version' '2'; then
         {
+            echo "[influxb2]"
             echo "org=$(bashio::config 'influxdb.organization')"
             echo "bucket=$(bashio::config 'influxdb.bucket')"
             echo "token=$(bashio::config 'influxdb.token')"
         } >> /etc/glances.conf
     fi
+
+    {
+        echo "protocol=${protocol}"
+        echo "host=$(bashio::config 'influxdb.host')"
+        echo "port=$(bashio::config 'influxdb.port')"
+        echo "prefix=$(bashio::config 'influxdb.prefix')"
+    } >> /etc/glances.conf
 fi

--- a/glances/rootfs/etc/services.d/influxdb/run
+++ b/glances/rootfs/etc/services.d/influxdb/run
@@ -4,21 +4,19 @@
 # Runs Glances InfluxDB Export
 # ==============================================================================
 declare -a options
-declare exporter
 
 if bashio::config.false 'influxdb.enabled'; then
     bashio::exit.ok
 fi
 
-
-exporter='influxdb'
-if bashio::config.equals 'influxdb.version' '2'; then
-exporter='influxdb2'
-fi
-
 options+=(-C /etc/glances.conf)
-options+=(--export "${exporter}")
 options+=(--quiet)
+
+if bashio::config.equals 'influxdb.version' '2'; then
+    options+=(--export influxdb2)
+else
+    options+=(--export influxdb)
+fi
 
 options+=(--time "$(bashio::config 'refresh_time')")
 

--- a/glances/rootfs/etc/services.d/influxdb/run
+++ b/glances/rootfs/etc/services.d/influxdb/run
@@ -4,13 +4,20 @@
 # Runs Glances InfluxDB Export
 # ==============================================================================
 declare -a options
+declare exporter
 
 if bashio::config.false 'influxdb.enabled'; then
     bashio::exit.ok
 fi
 
+
+exporter='influxdb'
+if bashio::config.equals 'influxdb.version' '2'; then
+exporter='influxdb2'
+fi
+
 options+=(-C /etc/glances.conf)
-options+=(--export influxdb)
+options+=(--export "${exporter}")
 options+=(--quiet)
 
 options+=(--time "$(bashio::config 'refresh_time')")


### PR DESCRIPTION
# Proposed Changes

Add configuration options+change influxdb service script to support Glances writing to an InfluxDB 2.x database.

Only different is this will export data to only single influxdb
and the config syntax I copied from [home assistant influxdb integration](https://www.home-assistant.io/integrations/influxdb/)

## Related Issues

hassio-addons/addon-glances#217
