### PR TITLE
Add support for InfluxDB2 exports

### DIFF
--- a/glances/DOCS.md
+++ b/glances/DOCS.md
@@ -45,6 +45,15 @@ influxdb:
   prefix: localhost
   interval: 60
   ssl: false
+influxdb2:
+    enabled: false
+    host: ""
+    port: 8086
+    org: ""
+    token: "!secret glances_influxdb2_token"
+    bucket: glances
+    prefix: localhost
+    interval: 60
 ```
 
 **Note**: _This is just an example, don't copy and paste it! Create your own!_
@@ -150,6 +159,54 @@ Defines the interval (in seconds) on how often Glances exports data to InfluxDB.
 Adding this option will allow SSL to be used on the InfluxDB connection. If not
 set will default to `false` which is the required setting for the Community
 InfluxDB add-on.
+
+### Option group `influxdb2`
+
+---
+
+The following options are for the option group: `influxdb2`. These settings
+only apply to the Glances influxdb2 data export.
+
+#### Option `influxdb2`: `enabled`
+
+Enables/Disables the Glances data export to InfluxDB2.
+
+#### Option `influxdb2`: `host`
+
+The hostname where InfluxDB2 is running.
+
+#### Option `influxdb2`: `port`
+
+The port on which InfluxDB2 is listening.
+
+#### Option `influxdb2`: `org`
+
+The Influxdb2 organization name which contains the Glances bucket.
+
+#### Option `influxdb2`: `token`
+
+The API token with a minimum of write access to the bucket.
+
+#### Option `influxdb2`: `bucket`
+
+The name of the bucket to store all Glances information into.
+
+**Note**: _It is strongly recommended to create a separate bucket for glances
+and not store this in the same database name as Home Assistant._
+
+#### Option `prefix`: `localhost`
+
+The hostname to append for exported data.
+
+**Note**: _For the Grafana Glances dashboard set this to `localhost`._
+
+#### Option `influxdb2`: `interval`
+
+Defines the interval (in seconds) on how often Glances exports data to influxdb2.
+
+#### Option `influxdb2`: `ssl`
+
+Adding this option will allow SSL to be used on the influxdb2 connection. If not set will default to `false`.
 
 ## Adding Glances as a sensor into Home Assistant
 

--- a/glances/DOCS.md
+++ b/glances/DOCS.md
@@ -185,7 +185,7 @@ The Influxdb2 organization name which contains the Glances bucket.
 
 #### Option `influxdb2`: `token`
 
-The API token with a minimum of write access to the bucket.
+The API token with a minimum of write access to the Glances bucket.
 
 #### Option `influxdb2`: `bucket`
 

--- a/glances/config.yaml
+++ b/glances/config.yaml
@@ -50,6 +50,15 @@ options:
     database: glances
     prefix: localhost
     interval: 60
+  influxdb2:
+    enabled: false
+    host: ""
+    port: 8086
+    org: ""
+    token: ""
+    bucket: glances
+    prefix: localhost
+    interval: 60
 schema:
   log_level: list(trace|debug|info|notice|warning|error|fatal)
   process_info: bool
@@ -64,6 +73,16 @@ schema:
     username: str
     password: password
     database: str
+    prefix: str
+    interval: int
+    ssl: bool?
+  influxdb2:
+    enabled: bool
+    host: str
+    port: port
+    org: str
+    token: password
+    bucket: str
     prefix: str
     interval: int
     ssl: bool?

--- a/glances/requirements.txt
+++ b/glances/requirements.txt
@@ -2,6 +2,7 @@ bottle==0.12.23
 docker==6.0.1
 glances==3.3.0.4
 influxdb==5.3.1
+influxdb-client==1.35.0
 netifaces==0.11.0
 paho-mqtt==1.6.1
 psutil==5.9.4

--- a/glances/rootfs/etc/cont-init.d/glances.sh
+++ b/glances/rootfs/etc/cont-init.d/glances.sh
@@ -35,3 +35,21 @@ if bashio::config.true 'influxdb.enabled'; then
         echo "protocol=${protocol}"
     } >> /etc/glances.conf
 fi
+
+if bashio::config.true 'influxdb2.enabled'; then
+    protocol='http'
+    if bashio::config.true 'influxdb.ssl'; then
+    protocol='https'
+    fi
+    # Modify the configuration
+    {
+        echo "[influxdb2]"
+        echo "host=$(bashio::config 'influxdb2.host')"
+        echo "port=$(bashio::config 'influxdb2.port')"
+        echo "user=$(bashio::config 'influxdb2.org')"
+        echo "password=$(bashio::config 'influxdb2.token')"
+        echo "db=$(bashio::config 'influxdb2.bucket')"
+        echo "prefix=$(bashio::config 'influxdb2.prefix')"
+        echo "protocol=${protocol}"
+    } >> /etc/glances.conf
+fi

--- a/glances/rootfs/etc/services.d/influxdb/run
+++ b/glances/rootfs/etc/services.d/influxdb/run
@@ -4,6 +4,7 @@
 # Runs Glances InfluxDB Export
 # ==============================================================================
 declare -a options
+declare -i influxdb-interval influxdb2-interval interval
 
 if bashio::config.false 'influxdb.enabled' && bashio::config.false 'influxdb2.enabled'; then
     bashio::exit.ok
@@ -29,10 +30,25 @@ if bashio::debug; then
     options+=(--debug)
 fi
 
+# get whichever interval is set or if both influxdb and influxdb2 take the larger
+if bashio::config.true 'influxdb.enabled'; then
+    influxdb_interval="$(bashio::config 'influxdb.interval')"
+fi
+
+if bashio::config.true 'influxdb2.enabled'; then
+    influxdb2_interval="$(bashio::config 'influxdb2.interval')"
+fi
+
+if (( ${influxdb_interval:-0} > ${influxdb2_interval:-0} )); then
+  interval=${influxdb_interval}
+else
+  interval=${influxdb2_interval}
+fi
+
 while true
 do
     # Interval
-    sleep "$(bashio::config 'influxdb.interval')"
+    sleep "${interval}"
 
     # Run Glances
     glances "${options[@]}"

--- a/glances/rootfs/etc/services.d/influxdb/run
+++ b/glances/rootfs/etc/services.d/influxdb/run
@@ -4,7 +4,7 @@
 # Runs Glances InfluxDB Export
 # ==============================================================================
 declare -a options
-declare -i influxdb-interval influxdb2-interval interval
+declare -i influxdb_interval influxdb2_interval interval
 
 if bashio::config.false 'influxdb.enabled' && bashio::config.false 'influxdb2.enabled'; then
     bashio::exit.ok
@@ -30,7 +30,7 @@ if bashio::debug; then
     options+=(--debug)
 fi
 
-# get whichever interval is set or if both influxdb and influxdb2 take the larger
+# Get whichever interval is set or if both influxdb and influxdb2 take the larger
 if bashio::config.true 'influxdb.enabled'; then
     influxdb_interval="$(bashio::config 'influxdb.interval')"
 fi

--- a/glances/rootfs/etc/services.d/influxdb/run
+++ b/glances/rootfs/etc/services.d/influxdb/run
@@ -5,12 +5,18 @@
 # ==============================================================================
 declare -a options
 
-if bashio::config.false 'influxdb.enabled'; then
+if bashio::config.false 'influxdb.enabled' && bashio::config.false 'influxdb2.enabled'; then
     bashio::exit.ok
 fi
 
 options+=(-C /etc/glances.conf)
-options+=(--export influxdb)
+if bashio::config.true 'influxdb.enabled'; then
+  options+=(--export influxdb)
+fi
+
+if bashio::config.true 'influxdb2.enabled'; then
+  options+=(--export influxdb2)
+fi
 options+=(--quiet)
 
 options+=(--time "$(bashio::config 'refresh_time')")


### PR DESCRIPTION
# Proposed Changes

Add configuration options to support export to InfluxDB2.  If both InfluxDB and InfluxDB2 are configured export to both. Because only a single interval is supported, in cases of running exports to both InfluxDB and InfluxDB2 the higher interval value is used (resolves one of the issues with #217) 

## Related Issues

#217 
