### PR TITLE
Fix influxdb2 configuration

### DIFF
--- a/glances/config.yaml
+++ b/glances/config.yaml
@@ -64,11 +64,11 @@ schema:
     enabled: bool
     host: str
     port: port
-    username: str
-    password: password
-    database: str
+    username: str?
+    password: password?
+    database: str?
     org: str?
-    prefix: str
+    prefix: str?
     interval: int
     ssl: bool?
     token: str?

--- a/glances/rootfs/etc/cont-init.d/glances.sh
+++ b/glances/rootfs/etc/cont-init.d/glances.sh
@@ -26,6 +26,10 @@ if bashio::config.true 'influxdb.enabled'; then
 
     # Modify the configuration
     if bashio::config.equals 'influxdb.version' '1'; then
+        bashio::config.require "influxdb.username"
+        bashio::config.require "influxdb.password"
+        bashio::config.require "influxdb.database"
+        bashio::config.require "influxdb.prefix"
         {
             echo "[influxdb]"
             echo "user=$(bashio::config 'influxdb.username')"
@@ -34,8 +38,11 @@ if bashio::config.true 'influxdb.enabled'; then
             echo "prefix=$(bashio::config 'influxdb.prefix')"
         } >> /etc/glances.conf
     elif bashio::config.equals 'influxdb.version' '2'; then
+        bashio::config.require "influxdb.org"
+        bashio::config.require "influxdb.bucket"
+        bashio::config.require "influxdb.token"
         {
-            echo "[influxdb 2]"
+            echo "[influxdb2]"
             echo "org=$(bashio::config 'influxdb.org')"
             echo "bucket=$(bashio::config 'influxdb.bucket')"
             echo "token=$(bashio::config 'influxdb.token')"


### PR DESCRIPTION
# Proposed Changes

Fixes the InfluxDB2 configuration of the add-on.

- Make InfluxDB V1 options optional (as one would not need them when using v2)
- Add programmatically checks to see if all options for either V1 or V2 are set.
- Fix a bug in the configuration generated of V2, which contained an additional space (`influxdb 2` instead of `influxdb2`).

