### PR TITLE
Migrate add-on data out of Home Assitant config dir

### DIFF
--- a/glances/config.yaml
+++ b/glances/config.yaml
@@ -22,10 +22,11 @@ ports_description:
 map:
   - addons
   - backup
-  - config:rw
+  - addon_config:rw
   - share
   - ssl
   - media
+  - homeassistant_config:rw # to enable migration to addon_config
 hassio_api: true
 auth_api: true
 docker_api: true

--- a/glances/config.yaml
+++ b/glances/config.yaml
@@ -26,7 +26,7 @@ map:
   - share
   - ssl
   - media
-  - homeassistant_config:rw # to enable migration to addon_config
+  - homeassistant_config:rw
 hassio_api: true
 auth_api: true
 docker_api: true

--- a/glances/rootfs/etc/cont-init.d/glances.sh
+++ b/glances/rootfs/etc/cont-init.d/glances.sh
@@ -8,13 +8,10 @@ bashio::require.unprotected
 
 # Migrate add-on data from the Home Assistant config directory,
 # to the add-on configuration directory.
-if ! bashio::fs.file_exists '/config/glances.conf' \
+if ! bashio::fs.file_exists '/config/glances/glances.conf' \
     && bashio::fs.file_exists '/homeassistant/glances/glances.conf'; then
-    shopt -s dotglob
-    mv /homeassistant/glances/* /config/ \
+    mv /homeassistant/glances /config/ \
         || bashio::exit.nok "Failed to migrate Glances configuration out of Home Assistant config directory"
-    rmdir /homeassistant/glances \
-        || bashio::log.warning "Failed to remove Glances configuration directory from Home Assistant config directory"
 fi
 
 # Ensure the configuration exists

--- a/glances/rootfs/etc/cont-init.d/glances.sh
+++ b/glances/rootfs/etc/cont-init.d/glances.sh
@@ -6,6 +6,15 @@
 declare protocol
 bashio::require.unprotected
 
+# Migrate add-on data from the Home Assistant config directory,
+# to the add-on configuration directory.
+if ! bashio::fs.file_exists '/config/glances.conf' \
+    && bashio::fs.file_exists '/homeassistant/glances/glances.conf'; then
+    shopt -s dotglob
+    mv /homeassistant/glances/* /config/ \
+        || bashio::exit.nok "Failed to migrate Glances configuration out of Home Assistant config directory"
+fi
+
 # Ensure the configuration exists
 if bashio::fs.file_exists '/config/glances/glances.conf'; then
     cp -f /config/glances/glances.conf /etc/glances.conf

--- a/glances/rootfs/etc/cont-init.d/glances.sh
+++ b/glances/rootfs/etc/cont-init.d/glances.sh
@@ -13,6 +13,8 @@ if ! bashio::fs.file_exists '/config/glances.conf' \
     shopt -s dotglob
     mv /homeassistant/glances/* /config/ \
         || bashio::exit.nok "Failed to migrate Glances configuration out of Home Assistant config directory"
+    rmdir /homeassistant/glances \
+        || bashio::log.warning "Failed to remove Glances configuration directory from Home Assistant config directory"
 fi
 
 # Ensure the configuration exists


### PR DESCRIPTION
# Proposed Changes

> (Describe the changes and rationale behind them)

This PR adds support for addon config to Glances, and migrates the config out of Home Assistant config dir into the addon config dir.

## Related Issues

Closes #543

Refs https://github.com/home-assistant/supervisor/pull/4650

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Updated configuration mapping for improved clarity in settings.
  - Added automated migration of Glances configuration files from the Home Assistant directory to the add-on configuration directory to enhance setup consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->