### PR TITLE
Remove deprecated codenotary field and armv7 architecture

### DIFF
--- a/glances/build.yaml
+++ b/glances/build.yaml
@@ -2,7 +2,3 @@
 build_from:
   aarch64: ghcr.io/hassio-addons/base:18.2.1
   amd64: ghcr.io/hassio-addons/base:18.2.1
-  armv7: ghcr.io/hassio-addons/base:18.2.1
-codenotary:
-  base_image: codenotary@frenck.dev
-  signer: codenotary@frenck.dev

--- a/glances/config.yaml
+++ b/glances/config.yaml
@@ -4,7 +4,6 @@ version: dev
 slug: glances
 description: A cross-platform system monitoring tool
 url: https://github.com/hassio-addons/addon-glances
-codenotary: codenotary@frenck.dev
 ingress: true
 ingress_port: 0
 ingress_stream: true
@@ -14,7 +13,6 @@ homeassistant: 0.92.0b2
 arch:
   - aarch64
   - amd64
-  - armv7
 ports:
   80/tcp: null
 ports_description:


### PR DESCRIPTION
## Summary

- Remove the deprecated `codenotary` field from `config.yaml` and `build.yaml`
- Remove the unsupported `armv7` architecture from both files

These fields are deprecated in the HA add-on schema and cause CI warnings/failures on newer builder versions.

Fixes #592, #600

## Test plan

- [ ] CI passes without the deprecated fields
- [ ] Add-on builds successfully for aarch64 and amd64
- [ ] Existing installations unaffected (fields were unused)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed support for 32-bit ARM (armv7) devices. The addon now supports aarch64 and amd64 architectures only.
  * Removed code signing verification configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->