### PR TITLE
Fix unbound variable error on startup

### DIFF
--- a/glances/rootfs/etc/services.d/glances/run
+++ b/glances/rootfs/etc/services.d/glances/run
@@ -4,8 +4,8 @@
 # Home Assistant Community App: Glances
 # Runs Glances
 # ==============================================================================
-declare -a options
-declare -a exporters
+declare -a options=()
+declare -a exporters=()
 
 bashio::log.info 'Starting Glances...'
 


### PR DESCRIPTION
# Proposed Changes

Fixes a startup crash caused by exporters being declared but not initialized, triggering set -u when the array was referenced before any element was assigned.

## Related Issues

> ([Github link][autolink-references] to related issues or pull requests)

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/
