### PR TITLE
Fix Glances web server dependencies

### DIFF
--- a/glances/requirements.txt
+++ b/glances/requirements.txt
@@ -1,5 +1,5 @@
-bottle==0.13.4
 docker==7.1.0
+fastapi==0.135.3
 glances==4.5.3
 influxdb==5.3.2
 influxdb-client==1.50.0
@@ -7,4 +7,5 @@ paho-mqtt==2.1.0
 psutil==7.2.2
 py-cpuinfo==9.0.0
 requests==2.33.1
+uvicorn==0.44.0
 zeroconf==0.148.0

--- a/glances/rootfs/etc/cont-init.d/glances.sh
+++ b/glances/rootfs/etc/cont-init.d/glances.sh
@@ -71,5 +71,3 @@ if bashio::config.true 'influxdb.enabled'; then
         echo "port=$(bashio::config 'influxdb.port')"
     } >> /etc/glances.conf
 fi
-
-ln -sf /dev/stdout /tmp/glances-root.log


### PR DESCRIPTION
# Proposed Changes

Glances 4.x replaced bottle with FastAPI for its web server. Adds the missing fastapi and uvicorn packages, removes the now-unused bottle, and drops the /dev/stdout symlink for the Glances log file which caused noisy RotatingFileHandler seek errors.
