### PR TITLE
♻️ Use bashio::app functions instead of deprecated bashio::addon

### DIFF
--- a/glances/rootfs/etc/cont-init.d/banner.sh
+++ b/glances/rootfs/etc/cont-init.d/banner.sh
@@ -7,16 +7,16 @@
 if bashio::supervisor.ping; then
     bashio::log.blue \
         '-----------------------------------------------------------'
-    bashio::log.blue " App: $(bashio::addon.name)"
-    bashio::log.blue " $(bashio::addon.description)"
+    bashio::log.blue " App: $(bashio::app.name)"
+    bashio::log.blue " $(bashio::app.description)"
     bashio::log.blue \
         '-----------------------------------------------------------'
 
-    bashio::log.blue " App version: $(bashio::addon.version)"
-    if bashio::var.true "$(bashio::addon.update_available)"; then
+    bashio::log.blue " App version: $(bashio::app.version)"
+    if bashio::var.true "$(bashio::app.update_available)"; then
         bashio::log.magenta ' There is an update available for this app!'
         bashio::log.magenta \
-            " Latest app version: $(bashio::addon.version_latest)"
+            " Latest app version: $(bashio::app.version_latest)"
         bashio::log.magenta ' Please consider upgrading as soon as possible.'
     else
         bashio::log.green ' You are running the latest version of this app.'

--- a/glances/rootfs/etc/cont-init.d/nginx.sh
+++ b/glances/rootfs/etc/cont-init.d/nginx.sh
@@ -7,20 +7,20 @@
 
 # Generate Ingress configuration
 bashio::var.json \
-    interface "$(bashio::addon.ip_address)" \
-    port "^$(bashio::addon.ingress_port)" \
+    interface "$(bashio::app.ip_address)" \
+    port "^$(bashio::app.ingress_port)" \
     | tempio \
         -template /etc/nginx/templates/ingress.gtpl \
         -out /etc/nginx/servers/ingress.conf
 
 # Generate direct access configuration, if enabled.
-if bashio::var.has_value "$(bashio::addon.port 80)"; then
+if bashio::var.has_value "$(bashio::app.port 80)"; then
     bashio::config.require.ssl
     bashio::var.json \
         certfile "$(bashio::config 'certfile')" \
         keyfile "$(bashio::config 'keyfile')" \
         leave_front_door_open "^$(bashio::config 'leave_front_door_open')" \
-        port "^$(bashio::addon.port 80)" \
+        port "^$(bashio::app.port 80)" \
         ssl "^$(bashio::config 'ssl')" \
         | tempio \
             -template /etc/nginx/templates/direct.gtpl \


### PR DESCRIPTION
# Proposed Changes

> (Describe the changes and rationale behind them)

Bashio v0.18.0 renamed the `bashio::addon.*` namespace to `bashio::app.*`. The old names still resolve, but they are now deprecated aliases that log a warning to the app log on first use of each function:

```
bashio::addon.name is deprecated, use bashio::app.name instead.
```

The base image v21 upgrade (#642) brought bashio from v0.17.5 to v0.19.0, so the new function names are now available and this repository can move over. This replaces all eight remaining call sites in `banner.sh` and `nginx.sh`:

| Old | New |
|---|---|
| `bashio::addon.name` | `bashio::app.name` |
| `bashio::addon.description` | `bashio::app.description` |
| `bashio::addon.version` | `bashio::app.version` |
| `bashio::addon.version_latest` | `bashio::app.version_latest` |
| `bashio::addon.update_available` | `bashio::app.update_available` |
| `bashio::addon.ip_address` | `bashio::app.ip_address` |
| `bashio::addon.ingress_port` | `bashio::app.ingress_port` |
| `bashio::addon.port` | `bashio::app.port` |

The signatures are unchanged, this is a pure rename.

Note this depends on the base image v21 upgrade: `bashio::app.*` does not exist in the bashio v0.17.5 shipped with base v20.1.1. Since #642 is merged, that dependency is satisfied.

The rest of the bashio API surface used in this repository was checked against v0.19.0 and needs no changes. Verified by building the image and confirming every `bashio::` function referenced in `run.sh`, `cont-init.d/` and `services.d/` resolves at runtime, plus `shellcheck` clean.

## Related Issues

> ([Github link][autolink-references] to related issues or pull requests)

Follow-up to #642

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated startup information to display the application’s name, description, version, and update status correctly.
  * Improved web server configuration for application access through ingress and direct access.
  * Preserved existing update notifications and SSL requirements for direct access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->